### PR TITLE
Update .gitignore to ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /pacts
 log
 logs
+
+# Vendoring directory
+/vendor/


### PR DESCRIPTION
Ignoring the `/vendor` folder to make it easy to see only the changes we make following along with the workshop tasks.